### PR TITLE
Bump to 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,11 @@ Simple retry mechanism for Java Callables.
 
 Add the JAR to your classpath and then use with 
 
-    Retriers.fixedTriesFixedDelay(yourCallable, someNumTries, waitTimeInMilliseconds)
+    RetryBuilders.fixedTriesFixedDelay(maxTries, waitMillisBetweenTries).buildAnnotatedFor(callable);
+
+or
+
+    RetryBuilders.basic()
+        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, Collections.<Class<? extends Exception>>singletonList(Exception.class))
+        .withDelayStrategy(new FixedDelayStrategy<>(waitMillisBetweenTries))
+	.buildAnnotatedFor(callable);

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.arjie.groundhog</groupId>
   <artifactId>groundhog</artifactId>
   <packaging>jar</packaging>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
 
   <name>Groundhog</name>
   <description>A simple retry mechanism for Java Callables</description>

--- a/src/main/java/com/arjie/groundhog/Retrier.java
+++ b/src/main/java/com/arjie/groundhog/Retrier.java
@@ -71,4 +71,18 @@ public class Retrier<V, S extends TryState> implements Callable<RetryResult<V, S
       throw new AccumulatedException(EXHAUSTED_TRIES_MESSAGE, state);
     }
   }
+
+  static class Pure<V, S> implements Callable<V> {
+
+    private final Callable<RetryResult<V, S>> retryCallable;
+
+    public Pure(Callable<RetryResult<V, S>> retryCallable) {
+      this.retryCallable = retryCallable;
+    }
+
+    @Override
+    public V call() throws Exception {
+      return retryCallable.call().getReturnValue();
+    }
+  }
 }

--- a/src/main/java/com/arjie/groundhog/Retrier.java
+++ b/src/main/java/com/arjie/groundhog/Retrier.java
@@ -14,12 +14,12 @@ public class Retrier<V, S extends TryState> implements Callable<RetryResult<V, S
 
   public static final String EXHAUSTED_TRIES_MESSAGE = "Can no longer try.";
   private final Callable<V> c;
-  private final TryStrategy<S> tryStrategy;
-  private final DelayStrategy<S> delayStrategy;
-  private final TryState.Factory<S> initialStateFactory;
+  private final TryStrategy<? super S> tryStrategy;
+  private final DelayStrategy<? super S> delayStrategy;
+  private final TryState.Factory<? extends S> initialStateFactory;
 
 
-  public Retrier(Callable<V> c, TryStrategy<S> tryStrategy, DelayStrategy<S> delayStrategy, TryState.Factory<S> initialStateFactory) {
+  public Retrier(Callable<V> c, TryStrategy<? super S> tryStrategy, DelayStrategy<? super S> delayStrategy, TryState.Factory<? extends S> initialStateFactory) {
     this.c = c;
     this.tryStrategy = tryStrategy;
     this.delayStrategy = delayStrategy;

--- a/src/main/java/com/arjie/groundhog/Retriers.java
+++ b/src/main/java/com/arjie/groundhog/Retriers.java
@@ -1,13 +1,10 @@
 package com.arjie.groundhog;
 
-import com.arjie.groundhog.impl.ExponentialDelayStrategy;
-import com.arjie.groundhog.impl.FixedTriesFixedDelayRetrier;
-import com.arjie.groundhog.impl.MaxTriesKnownExceptionTryStrategy;
-import com.arjie.groundhog.impl.NumTriesAndExceptionTracker;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Callable;
+
+import com.arjie.groundhog.impl.NumTriesAndExceptionTracker;
 
 @SuppressWarnings("unused")
 public class Retriers {
@@ -16,29 +13,29 @@ public class Retriers {
    * Retry given {@link Callable} up to a fixed maximum number of times, waiting a fixed time in between, and catching
    * only some {@link Exception}s. A re-attempt will be made only if the previous attempt failed.
    *
+   * @param <V> The return value of the {@link Callable}.
+   *
    * @param c The {@link Callable} to retry.
    * @param maxTries The maximum number of attempts to make.
    * @param waitMillisBetweenTries The time in milliseconds to wait between attempts.
    * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
-   * @param <V> The return value of the {@link Callable}.
-   *
    * @return A {@link Callable} that works as described above.
    */
-  public static <V> Retrier<V, NumTriesAndExceptionTracker> fixedTriesFixedDelay(Callable<V> c, int maxTries, long waitMillisBetweenTries, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
-    return new FixedTriesFixedDelayRetrier<>(c, maxTries, waitMillisBetweenTries, exceptionsToRetryOn);
+  public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesFixedDelay(Callable<V> c, int maxTries, long waitMillisBetweenTries, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
+    return RetryBuilders.fixedTriesFixedDelay(maxTries, waitMillisBetweenTries, exceptionsToRetryOn).buildAnnotatedFor(c);
   }
 
   /**
    * Catch all {@link Exception} but otherwise behave like {@link #fixedTriesFixedDelay(Callable, int, long, Collection)}
    *
+   * @param <V> The return value of the {@link Callable}.
+   *
    * @param c The {@link Callable} to retry.
    * @param maxTries The maximum number of attempts to make.
    * @param waitMillisBetweenTries The time in milliseconds to wait between attempts.
-   * @param <V> The return value of the {@link Callable}.
-   *
    * @return A {@link Callable} that works as described above.
    */
-  public static <V> Retrier<V, NumTriesAndExceptionTracker> fixedTriesFixedDelay(Callable<V> c, int maxTries, long waitMillisBetweenTries) {
+  public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesFixedDelay(Callable<V> c, int maxTries, long waitMillisBetweenTries) {
     return fixedTriesFixedDelay(c, maxTries, waitMillisBetweenTries, Collections.<Class<? extends Exception>>singletonList(Exception.class));
   }
 
@@ -46,36 +43,31 @@ public class Retriers {
    * Retry given {@link Callable} up to a fixed maximum number of times, exponentially backing off, and catching only
    * some {@link Exception}s. A re-attempt will be made only if the previous attempt failed.
    *
+   * @param <V> The return value of the {@link Callable}.
+   *
    * @param c The {@link Callable} to retry
    * @param maxTries The maximum number of attempts to make.
    * @param delayFactor The value to multiply the previous delay by to get the current delay
    * @param initialDelayInMillis The initial delay in milliseconds
    * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
-   * @param <V> The return value of the {@link Callable}.
-   *
    * @return A {@link Callable} that works as described above.
    */
-  public static <V> Retrier<V, NumTriesAndExceptionTracker> fixedTriesExponentialBackoff(Callable<V> c, int maxTries, double delayFactor, long initialDelayInMillis, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
-    return new Retrier<>(
-        c,
-        new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn),
-        new ExponentialDelayStrategy<NumTriesAndExceptionTracker>(delayFactor, initialDelayInMillis),
-        new NumTriesAndExceptionTracker.Factory()
-    );
+  public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesExponentialBackoff(Callable<V> c, int maxTries, double delayFactor, long initialDelayInMillis, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
+    return RetryBuilders.fixedTriesExponentialBackoff(maxTries, delayFactor, initialDelayInMillis, exceptionsToRetryOn).buildAnnotatedFor(c);
   }
 
   /**
    * Catch all {@link Exception} but otherwise behave like {@link #fixedTriesExponentialBackoff(Callable, int, double, long, Collection)}
    *
+   * @param <V> The return value of the {@link Callable}.
+   *
    * @param c The {@link Callable} to retry
    * @param maxTries The maximum number of attempts to make.
    * @param delayFactor The value to multiply the previous delay by to get the current delay
    * @param initialDelayInMillis The initial delay in milliseconds
-   * @param <V> The return value of the {@link Callable}.
-   *
    * @return A {@link Callable} that works as described above.
    */
-  public static <V> Retrier<V, NumTriesAndExceptionTracker> fixedTriesExponentialBackoff(Callable<V> c, int maxTries, double delayFactor, long initialDelayInMillis) {
+  public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesExponentialBackoff(Callable<V> c, int maxTries, double delayFactor, long initialDelayInMillis) {
     return fixedTriesExponentialBackoff(c, maxTries, delayFactor, initialDelayInMillis, Collections.<Class<? extends Exception>>singletonList(Exception.class));
   }
 }

--- a/src/main/java/com/arjie/groundhog/Retriers.java
+++ b/src/main/java/com/arjie/groundhog/Retriers.java
@@ -21,7 +21,10 @@ public class Retriers {
    * @param waitMillisBetweenTries The time in milliseconds to wait between attempts.
    * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
    * @return A {@link Callable} that works as described above.
+   *
+   * @deprecated Use {@link RetryBuilders#fixedTriesFixedDelay(int, long)} instead
    */
+  @Deprecated
   public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesFixedDelay(Callable<V> c, int maxTries, long waitMillisBetweenTries, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
     return RetryBuilders.fixedTriesFixedDelay(maxTries, waitMillisBetweenTries)
         .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
@@ -37,7 +40,10 @@ public class Retriers {
    * @param maxTries The maximum number of attempts to make.
    * @param waitMillisBetweenTries The time in milliseconds to wait between attempts.
    * @return A {@link Callable} that works as described above.
+   *
+   * @deprecated Use {@link RetryBuilders#fixedTriesFixedDelay(int, long)} instead
    */
+  @Deprecated
   public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesFixedDelay(Callable<V> c, int maxTries, long waitMillisBetweenTries) {
     return fixedTriesFixedDelay(c, maxTries, waitMillisBetweenTries, Collections.<Class<? extends Exception>>singletonList(Exception.class));
   }
@@ -54,7 +60,10 @@ public class Retriers {
    * @param initialDelayInMillis The initial delay in milliseconds
    * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
    * @return A {@link Callable} that works as described above.
+   *
+   * @deprecated Use {@link RetryBuilders#fixedTriesExponentialBackoff(int, double, long)} instead
    */
+  @Deprecated
   public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesExponentialBackoff(Callable<V> c, int maxTries, double delayFactor, long initialDelayInMillis, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
     return RetryBuilders.fixedTriesExponentialBackoff(maxTries, delayFactor, initialDelayInMillis)
         .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
@@ -71,7 +80,10 @@ public class Retriers {
    * @param delayFactor The value to multiply the previous delay by to get the current delay
    * @param initialDelayInMillis The initial delay in milliseconds
    * @return A {@link Callable} that works as described above.
+   *
+   * @deprecated Use {@link RetryBuilders#fixedTriesExponentialBackoff(int, double, long)} instead
    */
+  @Deprecated
   public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesExponentialBackoff(Callable<V> c, int maxTries, double delayFactor, long initialDelayInMillis) {
     return fixedTriesExponentialBackoff(c, maxTries, delayFactor, initialDelayInMillis, Collections.<Class<? extends Exception>>singletonList(Exception.class));
   }

--- a/src/main/java/com/arjie/groundhog/Retriers.java
+++ b/src/main/java/com/arjie/groundhog/Retriers.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.Callable;
 
+import com.arjie.groundhog.impl.MaxTriesKnownExceptionTryStrategy;
 import com.arjie.groundhog.impl.NumTriesAndExceptionTracker;
 
 @SuppressWarnings("unused")
@@ -22,7 +23,9 @@ public class Retriers {
    * @return A {@link Callable} that works as described above.
    */
   public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesFixedDelay(Callable<V> c, int maxTries, long waitMillisBetweenTries, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
-    return RetryBuilders.fixedTriesFixedDelay(maxTries, waitMillisBetweenTries, exceptionsToRetryOn).buildAnnotatedFor(c);
+    return RetryBuilders.fixedTriesFixedDelay(maxTries, waitMillisBetweenTries)
+        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
+        .buildAnnotatedFor(c);
   }
 
   /**
@@ -53,7 +56,9 @@ public class Retriers {
    * @return A {@link Callable} that works as described above.
    */
   public static <V> Callable<RetryResult<V, NumTriesAndExceptionTracker>> fixedTriesExponentialBackoff(Callable<V> c, int maxTries, double delayFactor, long initialDelayInMillis, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
-    return RetryBuilders.fixedTriesExponentialBackoff(maxTries, delayFactor, initialDelayInMillis, exceptionsToRetryOn).buildAnnotatedFor(c);
+    return RetryBuilders.fixedTriesExponentialBackoff(maxTries, delayFactor, initialDelayInMillis)
+        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
+        .buildAnnotatedFor(c);
   }
 
   /**

--- a/src/main/java/com/arjie/groundhog/RetryBuilder.java
+++ b/src/main/java/com/arjie/groundhog/RetryBuilder.java
@@ -1,0 +1,38 @@
+package com.arjie.groundhog;
+
+import java.util.concurrent.Callable;
+
+import com.arjie.groundhog.impl.FixedDelayStrategy;
+
+public class RetryBuilder<S extends TryState> {
+
+
+  private final TryState.Factory<S> initialStateFactory;
+  private TryStrategy<? super S> tryStrategy;
+  private DelayStrategy<? super S> delayStrategy;
+
+  public RetryBuilder(TryState.Factory<S> initialStateFactory) {
+    this.initialStateFactory = initialStateFactory;
+    this.tryStrategy = new TryStrategy.Forever<>();
+    this.delayStrategy = new FixedDelayStrategy<>(1000);
+  }
+
+  public RetryBuilder<S> withTryStrategy(TryStrategy<? super S> tryStrategy) {
+    this.tryStrategy = tryStrategy;
+    return this;
+  }
+
+  public RetryBuilder<S> withDelayStrategy(DelayStrategy<? super S> delayStrategy) {
+    this.delayStrategy = delayStrategy;
+    return this;
+  }
+
+  public <V> Callable<RetryResult<V, S>> buildAnnotatedFor(Callable<V> callable) {
+    return new Retrier<>(callable, tryStrategy, delayStrategy, initialStateFactory);
+  }
+
+  public <V> Callable<V> buildPurelyFor(Callable<V> callable) {
+    return new Retrier.Pure<>(buildAnnotatedFor(callable));
+  }
+
+}

--- a/src/main/java/com/arjie/groundhog/RetryBuilders.java
+++ b/src/main/java/com/arjie/groundhog/RetryBuilders.java
@@ -1,6 +1,6 @@
 package com.arjie.groundhog;
 
-import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.Callable;
 
 import com.arjie.groundhog.impl.ExponentialDelayStrategy;
@@ -11,19 +11,25 @@ import com.arjie.groundhog.impl.NumTriesAndExceptionTracker;
 public class RetryBuilders {
 
   /**
+   * @return A retrier that retries forever with a fixed delay
+   */
+  public static RetryBuilder<NumTriesAndExceptionTracker> basic() {
+    return new RetryBuilder<>(new NumTriesAndExceptionTracker.Factory());
+  }
+
+  /**
    * Create a retrier that will retry a given {@link Callable} up to a fixed maximum number of times,
    * waiting a fixed time in between, and catching only some {@link Exception}s.
    * A re-attempt will be made only if the previous attempt failed.
    *
    * @param maxTries The maximum number of attempts to make.
    * @param waitMillisBetweenTries The time in milliseconds to wait between attempts.
-   * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
    *
    * @return A {@link RetryBuilder} that works as described above.
    */
-  public static RetryBuilder<NumTriesAndExceptionTracker> fixedTriesFixedDelay(int maxTries, long waitMillisBetweenTries, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
-    return new RetryBuilder<>(new NumTriesAndExceptionTracker.Factory())
-        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
+  public static RetryBuilder<NumTriesAndExceptionTracker> fixedTriesFixedDelay(int maxTries, long waitMillisBetweenTries) {
+    return basic()
+        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, Collections.<Class<? extends Exception>>singletonList(Exception.class)))
         .withDelayStrategy(new FixedDelayStrategy<>(waitMillisBetweenTries));
   }
 
@@ -35,13 +41,12 @@ public class RetryBuilders {
    * @param maxTries The maximum number of attempts to make.
    * @param delayFactor The value to multiply the previous delay by to get the current delay
    * @param initialDelayInMillis The initial delay in milliseconds
-   * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
    *
    * @return A {@link Callable} that works as described above.
    */
-  public static RetryBuilder<NumTriesAndExceptionTracker> fixedTriesExponentialBackoff(int maxTries, double delayFactor, long initialDelayInMillis, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
-    return new RetryBuilder<>(new NumTriesAndExceptionTracker.Factory())
-        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
+  public static RetryBuilder<NumTriesAndExceptionTracker> fixedTriesExponentialBackoff(int maxTries, double delayFactor, long initialDelayInMillis) {
+    return basic()
+        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries))
         .withDelayStrategy(new ExponentialDelayStrategy<NumTriesAndExceptionTracker>(delayFactor, initialDelayInMillis));
   }
 

--- a/src/main/java/com/arjie/groundhog/RetryBuilders.java
+++ b/src/main/java/com/arjie/groundhog/RetryBuilders.java
@@ -1,0 +1,48 @@
+package com.arjie.groundhog;
+
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+import com.arjie.groundhog.impl.ExponentialDelayStrategy;
+import com.arjie.groundhog.impl.FixedDelayStrategy;
+import com.arjie.groundhog.impl.MaxTriesKnownExceptionTryStrategy;
+import com.arjie.groundhog.impl.NumTriesAndExceptionTracker;
+
+public class RetryBuilders {
+
+  /**
+   * Create a retrier that will retry a given {@link Callable} up to a fixed maximum number of times,
+   * waiting a fixed time in between, and catching only some {@link Exception}s.
+   * A re-attempt will be made only if the previous attempt failed.
+   *
+   * @param maxTries The maximum number of attempts to make.
+   * @param waitMillisBetweenTries The time in milliseconds to wait between attempts.
+   * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
+   *
+   * @return A {@link RetryBuilder} that works as described above.
+   */
+  public static RetryBuilder<NumTriesAndExceptionTracker> fixedTriesFixedDelay(int maxTries, long waitMillisBetweenTries, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
+    return new RetryBuilder<>(new NumTriesAndExceptionTracker.Factory())
+        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
+        .withDelayStrategy(new FixedDelayStrategy<>(waitMillisBetweenTries));
+  }
+
+  /**
+   * Create a retrier that will retry given {@link Callable} up to a fixed maximum number of times,
+   * exponentially backing off, and catching only some {@link Exception}s.
+   * A re-attempt will be made only if the previous attempt failed.
+   *
+   * @param maxTries The maximum number of attempts to make.
+   * @param delayFactor The value to multiply the previous delay by to get the current delay
+   * @param initialDelayInMillis The initial delay in milliseconds
+   * @param exceptionsToRetryOn The exceptions to catch and retry on. Others will be propagated up the chain normally.
+   *
+   * @return A {@link Callable} that works as described above.
+   */
+  public static RetryBuilder<NumTriesAndExceptionTracker> fixedTriesExponentialBackoff(int maxTries, double delayFactor, long initialDelayInMillis, Collection<Class<? extends Exception>> exceptionsToRetryOn) {
+    return new RetryBuilder<>(new NumTriesAndExceptionTracker.Factory())
+        .withTryStrategy(new MaxTriesKnownExceptionTryStrategy<>(maxTries, exceptionsToRetryOn))
+        .withDelayStrategy(new ExponentialDelayStrategy<NumTriesAndExceptionTracker>(delayFactor, initialDelayInMillis));
+  }
+
+}

--- a/src/main/java/com/arjie/groundhog/TryStrategy.java
+++ b/src/main/java/com/arjie/groundhog/TryStrategy.java
@@ -11,4 +11,11 @@ public interface TryStrategy<S extends TryState> {
    * @return true if we should make an attempt, false otherwise.
    */
   boolean shouldTry(S state);
+
+  class Forever<S extends TryState> implements TryStrategy<S> {
+    @Override
+    public boolean shouldTry(S state) {
+      return true;
+    }
+  }
 }

--- a/src/main/java/com/arjie/groundhog/impl/MaxTriesKnownExceptionTryStrategy.java
+++ b/src/main/java/com/arjie/groundhog/impl/MaxTriesKnownExceptionTryStrategy.java
@@ -1,8 +1,9 @@
 package com.arjie.groundhog.impl;
 
-import com.arjie.groundhog.TryStrategy;
-
 import java.util.Collection;
+import java.util.Collections;
+
+import com.arjie.groundhog.TryStrategy;
 
 public class MaxTriesKnownExceptionTryStrategy<S extends NumTriesAndExceptionTracker> implements TryStrategy<S> {
 
@@ -12,6 +13,10 @@ public class MaxTriesKnownExceptionTryStrategy<S extends NumTriesAndExceptionTra
   public MaxTriesKnownExceptionTryStrategy(long maxTries, Collection<Class<? extends Exception>> exceptionsToRetry) {
     this.maxTries = maxTries;
     this.exceptionsToRetry = exceptionsToRetry;
+  }
+
+  public MaxTriesKnownExceptionTryStrategy(long maxTries) {
+    this(maxTries, Collections.<Class<? extends Exception>>singletonList(Exception.class));
   }
 
   @Override


### PR DESCRIPTION
* Add Builders
* Weaken Type Restrictions
* Make it possible to receive a `Callable<V>` instead of just `Callable<RetryResult<V, S>>` 